### PR TITLE
update deprecated function units::make_unit to units::as_units

### DIFF
--- a/R/projection-units.r
+++ b/R/projection-units.r
@@ -12,5 +12,5 @@ projection_units <- function(x) {
   if (isTRUE(attr(class(x), "package") == "sp")) {
     x <- sf::st_as_sf(x)
   }
-  units::make_unit(sf::st_crs(x)$units)
+  units::as_units(sf::st_crs(x)$units)
 }


### PR DESCRIPTION
Gets rid of mildly annoying warnings